### PR TITLE
chore: pause audio player in error case BC-10138

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ export default class AudioPlayer extends Component {
       }).catch(() => {
         // will enter catch block is the source is unavailable.
         this.audio.pause();
-        this.setState({ loading: false });
+        this.setState({ loading: false, paused: true });
         // custom function that can be passed in this scenario.
         this.props.onLoadErrorHandler();
         this.updateSource();


### PR DESCRIPTION
https://teleport.video/video/message/v1/f5NEDv1F6gFs - video demonstration of the issue.
We are setting the paused state to true in case the audio is not available.