### PR TITLE
feat: set current time and disable pointer events on load STTNGS-2219

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -583,4 +583,5 @@ AudioPlayer.defaultProps = {
     progressBarFillColor: '#6699ff',
   },
   currentTime: 0,
+  autoplay: false,
 };

--- a/src/style.scss
+++ b/src/style.scss
@@ -559,6 +559,7 @@ $audio_player_play_btn_triangle_color: $audio_player_base_bg_color !default;
 
         &.loading {
             pointer-events: none;
+            cursor: progress;
             & .ivrplaybtn,
             & .ivrpausebtn {
                 display: none;

--- a/src/style.scss
+++ b/src/style.scss
@@ -559,7 +559,7 @@ $audio_player_play_btn_triangle_color: $audio_player_base_bg_color !default;
 
         &.loading {
             pointer-events: none;
-            cursor: progress;
+            cursor: default;
             & .ivrplaybtn,
             & .ivrpausebtn {
                 display: none;

--- a/src/style.scss
+++ b/src/style.scss
@@ -558,7 +558,7 @@ $audio_player_play_btn_triangle_color: $audio_player_base_bg_color !default;
         }
 
         &.loading {
-
+            pointer-events: none;
             & .ivrplaybtn,
             & .ivrpausebtn {
                 display: none;


### PR DESCRIPTION
Changes:
1. disable clicks in loading state
2. add a prop to manually set the current time
3. pass the error object and current time stamp of the audio in error callback