### PR TITLE
fix: show loader while the audio is being fetched IN-946

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -335,10 +335,11 @@ export default class AudioPlayer extends Component {
       }
       this.audio.play().then(() => { 
         this.audioPromise = undefined;  // Little funny logic to avoid this issue https://goo.gl/LdLk22
-    }).catch((error) => {
+    }).catch(async (error) => {
         this.audio.pause();
+        this.setState({ loading: true });
+        await this.props.onLoadErrorHandler({error, audioTimestamp: this.audio.currentTime });
         this.setState({ loading: false, paused: true });
-        this.props.onLoadErrorHandler({error, audioTimestamp: this.audio.currentTime });
     });
     } catch (error) {
       logError(error);


### PR DESCRIPTION
This PR adds a loading state when an error occurs and updates the error callback to be asynchronous. This allows the audio player to show a loading icon while the error is being handled. Once the handling is complete, the loading state is removed, and the player switches to a paused state.

Before the fix:

https://github.com/user-attachments/assets/522cedec-863b-4bdb-9cf2-77df4c592178

After the fix:

https://github.com/user-attachments/assets/48843fb5-484a-470d-a360-b0443d861908


